### PR TITLE
Prototype fog-to-central aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# Federated Fog Demo
+
+This repository shows a minimal prototype of hierarchical aggregation with [Flower](https://flower.ai) and MQTT.
+It uses a simple 1D CNN trained on the ECG5000 dataset.
+
+## Requirements
+
+Install the Python dependencies listed in `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+Optionally download the ECG5000 dataset locally:
+
+```bash
+python download_ecg5000.py
+```
+
+## Components
+
+- `server.py` – Central Flower server that aggregates partial updates and publishes the global model over MQTT.
+- `broker_fog.py` – MQTT broker logic that collects client updates and publishes a partial aggregate after receiving `K` updates from the same region.
+- `fog_flower_client.py` – Flower client running on the fog node. It receives partial aggregates from `broker_fog.py` and forwards them to the central server.
+- `client.py` – Example local client that trains on ECG5000 and pushes its update to the fog broker via MQTT.
+
+## Running the demo
+
+Start the following processes in separate terminals:
+
+1. **Central server**
+
+   ```bash
+   python server.py
+   ```
+
+2. **Fog broker** – collects updates from local clients
+
+   ```bash
+   python broker_fog.py
+   ```
+
+3. **Fog Flower client** – forwards region partials to the central server
+
+   ```bash
+   python fog_flower_client.py
+   ```
+
+4. **Local clients** – run one or more instances
+
+   ```bash
+   python client.py
+   ```
+
+Each client trains locally, publishes its update to the broker, and waits for the next global model. The broker computes a partial aggregate and `fog_flower_client.py` sends it to the Flower server, which performs the global aggregation and sends the updated model back over MQTT.

--- a/broker_fog.py
+++ b/broker_fog.py
@@ -82,43 +82,13 @@ def on_update(client, userdata, msg):
 # -----------------------------------------------------------------------------
 # THREAD: listen for partials and forward to Flower aggregator
 # -----------------------------------------------------------------------------
-def start_partial_forwarder():
-    """
-    In a real system you could call into your Flower server via gRPC here.
-    For demo, we simply log or re‐publish to GLOBAL_TOPIC.
-    """
-    def _on_partial(client, userdata, msg):
-        try:
-            data = json.loads(msg.payload.decode())
-            region = data["region"]
-            partial = data["partial_weights"]
-            print(f"[FORWARDER] Got partial from {region}, size={len(partial)} params")
-
-            # TODO: call Flower aggregator API (gRPC) with `partial`
-            # e.g. flower_aggregator.receive_partial(partial)
-
-            # As a placeholder, re‐publish as a “global” update:
-            client.publish(GLOBAL_TOPIC, json.dumps(partial))
-            print("[FORWARDER] Republished as GLOBAL_MODEL")
-
-        except Exception as e:
-            print("[FORWARDER ERROR]", e)
-
-    sub = mqtt.Client()
-    sub.on_connect = lambda c, u, f, rc: c.subscribe(PARTIAL_TOPIC)
-    sub.on_message = _on_partial
-    sub.connect(MQTT_BROKER, MQTT_PORT)
-    sub.loop_forever()
 
 
 # -----------------------------------------------------------------------------
 # MAIN
 # -----------------------------------------------------------------------------
 def main():
-    # 1) Start forwarder thread
-    threading.Thread(target=start_partial_forwarder, daemon=True).start()
-
-    # 2) Start primary broker to collect client updates
+    # Start primary broker to collect client updates
     mqttc = mqtt.Client()
     mqttc.on_connect = lambda c, u, f, rc: c.subscribe(UPDATE_TOPIC)
     mqttc.on_message = on_update

--- a/fog_flower_client.py
+++ b/fog_flower_client.py
@@ -1,0 +1,70 @@
+import json
+import time
+from typing import List
+
+import numpy as np
+import paho.mqtt.client as mqtt
+import flwr as fl
+
+from model import ECGModel, get_parameters, set_parameters
+
+# MQTT config
+MQTT_BROKER = "test.mosquitto.org"
+MQTT_PORT = 1883
+PARTIAL_TOPIC = "fl/partial"
+
+# -----------------------------------------------------------------------------
+# Flower client running on the fog node
+# -----------------------------------------------------------------------------
+class FogClient(fl.client.NumPyClient):
+    def __init__(self, server_address: str):
+        self.server_address = server_address
+        self.model = ECGModel()
+        self.param_names = list(self.model.state_dict().keys())
+        self.partial_weights = None
+
+        # Setup MQTT subscriber to receive partial aggregates
+        self.mqtt = mqtt.Client()
+        self.mqtt.on_connect = lambda c, u, f, rc: c.subscribe(PARTIAL_TOPIC)
+        self.mqtt.on_message = self._on_partial
+        self.mqtt.connect(MQTT_BROKER, MQTT_PORT)
+        self.mqtt.loop_start()
+
+    # MQTT callback when a partial aggregate is published by broker_fog
+    def _on_partial(self, client, userdata, msg):
+        try:
+            data = json.loads(msg.payload.decode())
+            self.partial_weights = data.get("partial_weights")
+            print(f"[FOG CLIENT] Received partial for region={data.get('region')}")
+        except Exception as e:
+            print("[FOG CLIENT] Error processing partial:", e)
+
+    # Flower NumPyClient interface
+    def get_parameters(self, config):
+        return get_parameters(self.model)
+
+    def fit(self, parameters: List[np.ndarray], config):
+        # Load new global parameters from the central server
+        set_parameters(self.model, parameters)
+
+        # Wait for a partial update from local clients
+        while self.partial_weights is None:
+            time.sleep(0.5)
+        # Convert partial dict to parameter list in correct order
+        partial_list = [
+            np.array(self.partial_weights[name], dtype=np.float32)
+            for name in self.param_names
+        ]
+        self.partial_weights = None
+        return partial_list, 0, {}
+
+    def evaluate(self, parameters, config):
+        return 0.0, 0, {}
+
+
+def main():
+    fl.client.start_numpy_client(server_address="0.0.0.0:8080", client=FogClient("0.0.0.0:8080"))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ torchvision
 numpy
 scikit-learn
 tslearn
+flwr
+paho-mqtt


### PR DESCRIPTION
## Summary
- update broker_fog to only collect client updates and publish partial aggregates
- add `fog_flower_client.py` bridging MQTT partials with Flower central server
- extend requirements with `flwr` and `paho-mqtt`
- add instructions for running the demo

## Testing
- `python -m py_compile fog_flower_client.py broker_fog.py client.py server.py model.py utils.py download_ecg5000.py`

------
https://chatgpt.com/codex/tasks/task_e_6887bfa0993c8332a8acd9914deb0234